### PR TITLE
fix: post-emulator regressions

### DIFF
--- a/src/features/collections/store/collectionSlice.ts
+++ b/src/features/collections/store/collectionSlice.ts
@@ -323,13 +323,13 @@ export const createCollection = createAppAsyncThunk<
       }
 
       const fdId = firestoreDatabaseId ?? getActiveFirestoreDatabase(project)?.id;
-      dispatch(
+      await dispatch(
         refreshCollections({
           project,
           refreshToken: project.refreshToken,
           ...(fdId ? { firestoreDatabaseId: fdId } : {}),
         }),
-      );
+      ).unwrap();
       return trimmedName;
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : 'Unknown error';

--- a/src/features/projects/components/sidebar/SidebarMenu.tsx
+++ b/src/features/projects/components/sidebar/SidebarMenu.tsx
@@ -166,12 +166,14 @@ function SidebarMenu({
             <Typography sx={{ fontSize: '0.8rem', color: 'text.primary', fontWeight: 600 }}>Firestore</Typography>
           </Box>
           <Divider />
-          <MenuItem onClick={() => handleAction(onAddFirestoreDatabase, menuTarget.project)}>
-            <ListItemIcon>
-              <AddIcon fontSize="small" />
-            </ListItemIcon>
-            Add database
-          </MenuItem>
+          {menuTarget.project.authMethod !== 'emulator' && (
+            <MenuItem onClick={() => handleAction(onAddFirestoreDatabase, menuTarget.project)}>
+              <ListItemIcon>
+                <AddIcon fontSize="small" />
+              </ListItemIcon>
+              Add database
+            </MenuItem>
+          )}
         </>
       ) : menuTarget?.menuType === 'firestoreDatabase' ? (
         <>

--- a/src/features/projects/components/sidebar/SidebarProjectsList.tsx
+++ b/src/features/projects/components/sidebar/SidebarProjectsList.tsx
@@ -430,18 +430,20 @@ function SidebarProjectsList({
                                       >
                                         Firestore
                                       </Typography>
-                                      <Tooltip title="Add database">
-                                        <IconButton
-                                          size="small"
-                                          onClick={(e) => {
-                                            e.stopPropagation();
-                                            onAddFirestoreDatabase(project);
-                                          }}
-                                          sx={{ p: 0.25, color: 'primary.main' }}
-                                        >
-                                          <AddIcon sx={{ fontSize: 16 }} />
-                                        </IconButton>
-                                      </Tooltip>
+                                      {project.authMethod !== 'emulator' && (
+                                        <Tooltip title="Add database">
+                                          <IconButton
+                                            size="small"
+                                            onClick={(e) => {
+                                              e.stopPropagation();
+                                              onAddFirestoreDatabase(project);
+                                            }}
+                                            sx={{ p: 0.25, color: 'primary.main' }}
+                                          >
+                                            <AddIcon sx={{ fontSize: 16 }} />
+                                          </IconButton>
+                                        </Tooltip>
+                                      )}
                                       <IconButton
                                         size="small"
                                         onClick={(e) => {
@@ -927,18 +929,20 @@ function SidebarProjectsList({
                               >
                                 Firestore
                               </Typography>
-                              <Tooltip title="Add database">
-                                <IconButton
-                                  size="small"
-                                  onClick={(e) => {
-                                    e.stopPropagation();
-                                    onAddFirestoreDatabase(project);
-                                  }}
-                                  sx={{ p: 0.25, color: 'primary.main' }}
-                                >
-                                  <AddIcon sx={{ fontSize: 16 }} />
-                                </IconButton>
-                              </Tooltip>
+                              {project.authMethod !== 'emulator' && (
+                                <Tooltip title="Add database">
+                                  <IconButton
+                                    size="small"
+                                    onClick={(e) => {
+                                      e.stopPropagation();
+                                      onAddFirestoreDatabase(project);
+                                    }}
+                                    sx={{ p: 0.25, color: 'primary.main' }}
+                                  >
+                                    <AddIcon sx={{ fontSize: 16 }} />
+                                  </IconButton>
+                                </Tooltip>
+                              )}
                               <IconButton
                                 size="small"
                                 onClick={(e) => {
@@ -1171,24 +1175,26 @@ function SidebarProjectsList({
                                   );
                                 })}
 
-                                <Box
-                                  onClick={(e) => {
-                                    e.stopPropagation();
-                                    onAddFirestoreDatabase(project);
-                                  }}
-                                  sx={{
-                                    display: 'flex',
-                                    alignItems: 'center',
-                                    px: 1,
-                                    py: 0.5,
-                                    cursor: 'pointer',
-                                    color: 'primary.main',
-                                    '&:hover': { bgcolor: 'action.hover' },
-                                  }}
-                                >
-                                  <AddIcon sx={{ fontSize: 14, mr: 0.5 }} />
-                                  <Typography sx={{ fontSize: '0.75rem' }}>Add database</Typography>
-                                </Box>
+                                {project.authMethod !== 'emulator' && (
+                                  <Box
+                                    onClick={(e) => {
+                                      e.stopPropagation();
+                                      onAddFirestoreDatabase(project);
+                                    }}
+                                    sx={{
+                                      display: 'flex',
+                                      alignItems: 'center',
+                                      px: 1,
+                                      py: 0.5,
+                                      cursor: 'pointer',
+                                      color: 'primary.main',
+                                      '&:hover': { bgcolor: 'action.hover' },
+                                    }}
+                                  >
+                                    <AddIcon sx={{ fontSize: 14, mr: 0.5 }} />
+                                    <Typography sx={{ fontSize: '0.75rem' }}>Add database</Typography>
+                                  </Box>
+                                )}
                               </Box>
                             </Collapse>
                           </Box>
@@ -1392,18 +1398,20 @@ function SidebarProjectsList({
                               >
                                 Firestore
                               </Typography>
-                              <Tooltip title="Add database">
-                                <IconButton
-                                  size="small"
-                                  onClick={(e) => {
-                                    e.stopPropagation();
-                                    onAddFirestoreDatabase(project);
-                                  }}
-                                  sx={{ p: 0.25, color: 'primary.main' }}
-                                >
-                                  <AddIcon sx={{ fontSize: 16 }} />
-                                </IconButton>
-                              </Tooltip>
+                              {project.authMethod !== 'emulator' && (
+                                <Tooltip title="Add database">
+                                  <IconButton
+                                    size="small"
+                                    onClick={(e) => {
+                                      e.stopPropagation();
+                                      onAddFirestoreDatabase(project);
+                                    }}
+                                    sx={{ p: 0.25, color: 'primary.main' }}
+                                  >
+                                    <AddIcon sx={{ fontSize: 16 }} />
+                                  </IconButton>
+                                </Tooltip>
+                              )}
                               <IconButton
                                 size="small"
                                 onClick={(e) => {
@@ -1636,24 +1644,26 @@ function SidebarProjectsList({
                                   );
                                 })}
 
-                                <Box
-                                  onClick={(e) => {
-                                    e.stopPropagation();
-                                    onAddFirestoreDatabase(project);
-                                  }}
-                                  sx={{
-                                    display: 'flex',
-                                    alignItems: 'center',
-                                    px: 1,
-                                    py: 0.5,
-                                    cursor: 'pointer',
-                                    color: 'primary.main',
-                                    '&:hover': { bgcolor: 'action.hover' },
-                                  }}
-                                >
-                                  <AddIcon sx={{ fontSize: 14, mr: 0.5 }} />
-                                  <Typography sx={{ fontSize: '0.75rem' }}>Add database</Typography>
-                                </Box>
+                                {project.authMethod !== 'emulator' && (
+                                  <Box
+                                    onClick={(e) => {
+                                      e.stopPropagation();
+                                      onAddFirestoreDatabase(project);
+                                    }}
+                                    sx={{
+                                      display: 'flex',
+                                      alignItems: 'center',
+                                      px: 1,
+                                      py: 0.5,
+                                      cursor: 'pointer',
+                                      color: 'primary.main',
+                                      '&:hover': { bgcolor: 'action.hover' },
+                                    }}
+                                  >
+                                    <AddIcon sx={{ fontSize: 14, mr: 0.5 }} />
+                                    <Typography sx={{ fontSize: '0.75rem' }}>Add database</Typography>
+                                  </Box>
+                                )}
                               </Box>
                             </Collapse>
                           </Box>

--- a/src/features/projects/store/projectsSlice.ts
+++ b/src/features/projects/store/projectsSlice.ts
@@ -697,7 +697,9 @@ const projectsSlice = createSlice({
             if (item.id === projectId) {
               const proj = item as Project;
               if (
-                (proj.authMethod === 'serviceAccount' || proj.authMethod === 'google') &&
+                (proj.authMethod === 'serviceAccount' ||
+                  proj.authMethod === 'google' ||
+                  proj.authMethod === 'emulator') &&
                 firestoreDatabaseId &&
                 proj.firestoreDatabases?.length
               ) {


### PR DESCRIPTION
## Summary

1. Fixes a regression where created collections didn't appear in the sidebar for service account and emulator projects (required manual "Refresh Collections"). Root cause: fire-and-forget `dispatch(refreshCollections)` in `createCollection` silently swallowed errors. 
2. Created collections not appearing at all for emulators: `refreshCollections.fulfilled` reducer was missing `emulator` auth method.
3. Hide "Add database" UI for emulator projects (emulator doesn't support named databases).

- Fix `refreshCollections.fulfilled` reducer to handle `emulator` auth method
- Disable "Add database" toolbar buttons and context menu item for emulator projects
- Await `refreshCollections` dispatch in `createCollection` thunk so errors aren't silently swallowed

## Test plan

- [x] Create a collection via service account project — sidebar updates immediately
- [x] Create a collection via emulator project — sidebar updates immediately
- [x] "Add database" buttons are hidden for emulator projects
- [x] "Add database" context menu item is hidden for emulator projects