### PR TITLE
Add Arch Linux AUR installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,14 @@ Download the latest release for your platform from [GitHub Releases](https://git
 | macOS    | `.dmg` (Intel & Apple Silicon)    |
 | Linux    | `.AppImage`, `.deb`, or `.tar.gz` |
 
+#### Arch Linux (AUR)
+
+Arch Linux users can install Firestudio from the AUR:
+
+```bash
+yay -S firestudio-bin
+```
+
 #### macOS Users: First Launch
 
 Since the app is not signed with an Apple Developer certificate, macOS will show a security warning on first launch.


### PR DESCRIPTION
## Summary

I've created [firestudio-bin](https://aur.archlinux.org/packages/firestudio-bin) package on AUR which is based on the official tarball.

This PR will add Arch Linux AUR installation instructions to the README.

## Changes

- Added `yay -S firestudio-bin` installation instructions.

## Testing

- Built and installed the package locally with `makepkg -si`.
- Confirmed Firestudio launches correctly.
- Verified successful installation via `yay` and `paru`.

## Notes

The AUR package is independently maintained by me.