### PR TITLE
fix: serialize Firestore references as plain strings over IPC

### DIFF
--- a/electron/controllers/firestore/documentList.js
+++ b/electron/controllers/firestore/documentList.js
@@ -1,7 +1,9 @@
+const { firestoreDocumentToData } = require('../../utils/firestoreHelpers');
+
 const PHANTOM_SCAN_MAX_DOCS = 1000;
 
 function toDocumentEntry(doc) {
-  return { id: doc.id, data: doc.data(), path: doc.ref.path };
+  return { id: doc.id, data: firestoreDocumentToData(doc), path: doc.ref.path };
 }
 
 function toPhantomEntry(ref) {

--- a/electron/controllers/firestoreController.js
+++ b/electron/controllers/firestoreController.js
@@ -7,6 +7,7 @@ const { ipcMain, dialog } = require('electron');
 const fs = require('fs');
 const vm = require('vm');
 const { fetchDocumentsPage } = require('./firestore/documentList');
+const { firestoreDocumentToData } = require('../utils/firestoreHelpers');
 
 let adminRef = null;
 let dbRef = null;
@@ -72,7 +73,7 @@ function registerHandlers() {
         success: true,
         document: {
           id: doc.id,
-          data: doc.data(),
+          data: firestoreDocumentToData(doc),
           path: doc.ref.path,
           subcollections: subcollections.map((col) => col.id),
         },
@@ -158,7 +159,7 @@ function registerHandlers() {
       const snapshot = await query.get();
       const documents = [];
       snapshot.forEach((doc) => {
-        documents.push({ id: doc.id, data: doc.data(), path: doc.ref.path });
+        documents.push({ id: doc.id, data: firestoreDocumentToData(doc), path: doc.ref.path });
       });
 
       return { success: true, documents };
@@ -175,7 +176,7 @@ function registerHandlers() {
       const snapshot = await dbRef.collection(collectionPath).get();
       const documents = {};
       snapshot.forEach((doc) => {
-        documents[doc.id] = doc.data();
+        documents[doc.id] = firestoreDocumentToData(doc);
       });
 
       const { filePath } = await dialog.showSaveDialog({
@@ -262,14 +263,14 @@ function registerHandlers() {
       const documents = [];
       if (queryResult?.forEach) {
         queryResult.forEach((doc) => {
-          documents.push({ id: doc.id, data: doc.data(), path: doc.ref.path });
+          documents.push({ id: doc.id, data: firestoreDocumentToData(doc), path: doc.ref.path });
         });
       } else if (queryResult?.docs) {
         queryResult.docs.forEach((doc) => {
-          documents.push({ id: doc.id, data: doc.data(), path: doc.ref.path });
+          documents.push({ id: doc.id, data: firestoreDocumentToData(doc), path: doc.ref.path });
         });
       } else if (queryResult?.exists !== undefined && queryResult.exists) {
-        documents.push({ id: queryResult.id, data: queryResult.data(), path: queryResult.ref.path });
+        documents.push({ id: queryResult.id, data: firestoreDocumentToData(queryResult), path: queryResult.ref.path });
       }
 
       return { success: true, documents };
@@ -302,7 +303,7 @@ function registerHandlers() {
         const snapshot = await col.get();
         const documents = {};
         snapshot.forEach((doc) => {
-          documents[doc.id] = doc.data();
+          documents[doc.id] = firestoreDocumentToData(doc);
         });
         allData[col.id] = documents;
       }

--- a/electron/controllers/firestoreController.test.js
+++ b/electron/controllers/firestoreController.test.js
@@ -146,7 +146,7 @@ describe('firestoreController', () => {
               valueType: 'referenceValue',
             },
             ts: {
-              timestampValue: '2026-01-01T00:00:00.000Z',
+              timestampValue: { seconds: 1767225600, nanos: 0 },
               valueType: 'timestampValue',
             },
           },
@@ -164,6 +164,31 @@ describe('firestoreController', () => {
 
     expect(result.success).toBe(true);
     expect(result.documents[0].data.owner).toBe('projects/p/databases/(default)/documents/users/1');
+    expect(result.documents[0].data.ts).toEqual({ _seconds: 1767225600, _nanoseconds: 0 });
+  });
+
+  it('getDocuments decodes RFC3339 string timestamps as the REST path does', async () => {
+    const snapshot = {
+      docs: [
+        {
+          id: 'a',
+          ref: { path: 'col/a' },
+          _fieldsProto: {
+            ts: { timestampValue: '2026-01-01T00:00:00.000Z', valueType: 'timestampValue' },
+          },
+        },
+      ],
+      size: 1,
+    };
+    const mockCollection = {
+      limit: vi.fn().mockReturnValue({ get: vi.fn().mockResolvedValue(snapshot) }),
+      listDocuments: vi.fn().mockResolvedValue([]),
+    };
+    setRefs(null, { collection: vi.fn().mockReturnValue(mockCollection) });
+
+    const result = await handlers['firestore:getDocuments'](null, { collectionPath: 'col' });
+
+    expect(result.success).toBe(true);
     expect(result.documents[0].data.ts).toEqual({ _seconds: 1767225600, _nanoseconds: 0 });
   });
 

--- a/electron/controllers/firestoreController.test.js
+++ b/electron/controllers/firestoreController.test.js
@@ -133,6 +133,40 @@ describe('firestoreController', () => {
     expect(result.documents.map((d) => d.id)).toEqual(['a']);
   });
 
+  it('getDocuments decodes reference fields into plain strings (IPC-cloneable)', async () => {
+    const snapshot = {
+      docs: [
+        {
+          id: 'a',
+          ref: { path: 'col/a' },
+          _fieldsProto: {
+            name: { stringValue: 'test', valueType: 'stringValue' },
+            owner: {
+              referenceValue: 'projects/p/databases/(default)/documents/users/1',
+              valueType: 'referenceValue',
+            },
+            ts: {
+              timestampValue: '2026-01-01T00:00:00.000Z',
+              valueType: 'timestampValue',
+            },
+          },
+        },
+      ],
+      size: 1,
+    };
+    const mockCollection = {
+      limit: vi.fn().mockReturnValue({ get: vi.fn().mockResolvedValue(snapshot) }),
+      listDocuments: vi.fn().mockResolvedValue([]),
+    };
+    setRefs(null, { collection: vi.fn().mockReturnValue(mockCollection) });
+
+    const result = await handlers['firestore:getDocuments'](null, { collectionPath: 'col' });
+
+    expect(result.success).toBe(true);
+    expect(result.documents[0].data.owner).toBe('projects/p/databases/(default)/documents/users/1');
+    expect(result.documents[0].data.ts).toEqual({ _seconds: 1767225600, _nanoseconds: 0 });
+  });
+
   // ─── listSubcollections ──────────────────────────────────────────────────
 
   it('listSubcollections returns subcollection ids for a document path', async () => {

--- a/electron/utils/firestoreHelpers.js
+++ b/electron/utils/firestoreHelpers.js
@@ -54,8 +54,12 @@ function parseFirestoreValue(value) {
   if (value.booleanValue !== undefined) return value.booleanValue;
   if (value.nullValue !== undefined) return null;
   if (value.timestampValue !== undefined) {
-    const date = new Date(value.timestampValue);
-    return { _seconds: Math.floor(date.getTime() / 1000), _nanoseconds: 0 };
+    // REST JSON serializes timestamps as RFC3339 strings, while the admin SDK
+    // gRPC proto exposes them as { seconds, nanos } objects.
+    const ts = value.timestampValue;
+    const seconds = typeof ts === 'string' ? Math.floor(new Date(ts).getTime() / 1000) : Number(ts.seconds);
+    const nanos = typeof ts === 'string' ? 0 : ts.nanos || 0;
+    return { _seconds: seconds, _nanoseconds: nanos };
   }
   if (value.geoPointValue !== undefined) {
     return {

--- a/electron/utils/firestoreHelpers.js
+++ b/electron/utils/firestoreHelpers.js
@@ -101,9 +101,21 @@ function dataToFirestoreFields(data) {
   return fields;
 }
 
+/**
+ * Decodes a Firestore document into plain cloneable data.
+ * Unlike doc.data(), references become plain strings instead of
+ * DocumentReference instances, which cannot cross the IPC boundary.
+ * @param {Object} doc - Firestore DocumentSnapshot
+ * @returns {Object} - Plain data object
+ */
+function firestoreDocumentToData(doc) {
+  return parseFirestoreDocument(doc._fieldsProto || {});
+}
+
 module.exports = {
   convertToFirestoreValue,
   parseFirestoreValue,
   parseFirestoreDocument,
   dataToFirestoreFields,
+  firestoreDocumentToData,
 };

--- a/src/features/collections/components/CollectionTab.tsx
+++ b/src/features/collections/components/CollectionTab.tsx
@@ -71,6 +71,7 @@ import ViewTabs from './ViewTabs';
 import TableView from './TableView';
 import TreeView from './TreeView';
 import JsonView from './JsonView';
+import { useTreeSubcollections } from '../hooks/useTreeSubcollections';
 import CreateDocumentDialog from './CreateDocumentDialog';
 import SettingsDialog from '../../../app/components/SettingsDialog';
 
@@ -81,6 +82,8 @@ interface EditingCell {
   field: string;
   originalValue?: FirestoreValue;
   originalType?: string;
+  docData?: DocumentData;
+  docCollectionPath?: string;
 }
 
 interface CollectionTabProps {
@@ -379,6 +382,10 @@ const CollectionTab: React.FC<CollectionTabProps> = ({ project, collectionPath, 
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [deleteLoading, setDeleteLoading] = useState(false);
 
+  // Nested subcollection data (shared with the tree view so saves can refresh it)
+  const { subcollectionsByDocPath, documentsByPath, ensureSubcollections, ensureDocuments, refreshDocuments } =
+    useTreeSubcollections(project, firestoreDatabaseId);
+
   // Initialize expanded nodes when documents load
   useEffect(() => {
     if (documents.length > 0) {
@@ -458,19 +465,35 @@ const CollectionTab: React.FC<CollectionTabProps> = ({ project, collectionPath, 
   }, []);
 
   // Cell Editing Handlers
-  const handleCellEdit = useCallback((docId: string | null, field: string | null, value: FirestoreValue) => {
-    // If called with null values, clear editing state (cancel operation)
-    if (docId === null || field === null) {
-      setEditingCell(null);
-      setEditValue('');
-      return;
-    }
+  const handleCellEdit = useCallback(
+    (
+      docId: string | null,
+      field: string | null,
+      value: FirestoreValue,
+      docData?: DocumentData | boolean,
+      docCollectionPath?: string,
+    ) => {
+      // If called with null values, clear editing state (cancel operation)
+      if (docId === null || field === null) {
+        setEditingCell(null);
+        setEditValue('');
+        return;
+      }
 
-    const type = getValueType(value);
-    // Store original value for type preservation when saving
-    setEditingCell({ docId, field, originalValue: value, originalType: type });
-    setEditValue(serializeForEdit(value, type));
-  }, []);
+      const type = getValueType(value);
+      // Store original value for type preservation when saving
+      setEditingCell({
+        docId,
+        field,
+        originalValue: value,
+        originalType: type,
+        docData: docData && typeof docData === 'object' ? docData : undefined,
+        docCollectionPath: docCollectionPath && typeof docCollectionPath === 'string' ? docCollectionPath : undefined,
+      });
+      setEditValue(serializeForEdit(value, type));
+    },
+    [],
+  );
 
   // Save cell - can pass explicit docId, field, value for direct saving (avoids stale closure issues)
   const handleCellSave = useCallback(
@@ -481,10 +504,15 @@ const CollectionTab: React.FC<CollectionTabProps> = ({ project, collectionPath, 
 
       if (!docId || !field) return;
 
-      const doc = documents.find((d) => d.id === docId);
-      if (!doc) return;
+      // Subcollection documents are saved to their own collection path; root docs keep the tab's path
+      const targetCollectionPath = editingCell?.docCollectionPath ?? collectionPath;
+      const docData =
+        editingCell?.docData && typeof editingCell.docData === 'object'
+          ? editingCell.docData
+          : documents.find((d) => d.id === docId)?.data;
+      if (!docData) return;
 
-      const oldValue = editingCell?.originalValue ?? doc.data?.[field];
+      const oldValue = editingCell?.originalValue ?? docData[field];
 
       // Determine the new value - use explicit if provided, otherwise parse editValue
       let newValue: FirestoreValue = explicitValue !== undefined ? explicitValue : parseEditValue(editValue);
@@ -496,26 +524,40 @@ const CollectionTab: React.FC<CollectionTabProps> = ({ project, collectionPath, 
         return;
       }
 
-      const newData = { ...doc.data, [field]: newValue };
+      const newData = { ...docData, [field]: newValue };
 
       try {
         await dispatch(
           updateDocument({
             project,
-            collection: collectionPath,
+            collection: targetCollectionPath,
             docId,
             docData: newData,
             firestoreDatabaseId,
           }),
         ).unwrap();
         showMessage?.(`Updated document ${docId}`, 'success');
+        if (targetCollectionPath !== collectionPath) {
+          refreshDocuments(targetCollectionPath);
+        }
       } catch (error) {
         showError(error);
       }
 
       setEditingCell(null);
     },
-    [editingCell, editValue, documents, dispatch, project, collectionPath, firestoreDatabaseId, showMessage, showError],
+    [
+      editingCell,
+      editValue,
+      documents,
+      dispatch,
+      project,
+      collectionPath,
+      firestoreDatabaseId,
+      refreshDocuments,
+      showMessage,
+      showError,
+    ],
   );
 
   const handleCellKeyDown = useCallback(
@@ -741,8 +783,6 @@ const CollectionTab: React.FC<CollectionTabProps> = ({ project, collectionPath, 
 
             {viewMode === 'tree' && (
               <TreeView
-                project={project}
-                firestoreDatabaseId={firestoreDatabaseId}
                 collectionPath={collectionPath}
                 documents={documents}
                 expandedNodes={expandedNodes}
@@ -758,6 +798,11 @@ const CollectionTab: React.FC<CollectionTabProps> = ({ project, collectionPath, 
                 getType={getType}
                 getTypeColor={getColor}
                 formatValue={formatValue}
+                subcollectionsByDocPath={subcollectionsByDocPath}
+                documentsByPath={documentsByPath}
+                ensureSubcollections={ensureSubcollections}
+                ensureDocuments={ensureDocuments}
+                refreshDocuments={refreshDocuments}
               />
             )}
 

--- a/src/features/collections/components/CollectionTab.tsx
+++ b/src/features/collections/components/CollectionTab.tsx
@@ -46,7 +46,6 @@ import { RootState, AppDispatch } from '../../../app/store';
 import { Project } from '../../projects/store/projectsSlice';
 import { buildCollectionStateKey } from '../../projects/utils/firestoreDatabaseUtils';
 import { FirestoreValue } from '../../../shared/utils/firestoreUtils';
-import { isFirestoreTimestamp, isIsoDateString, isUnixTimestampMs } from '../../../shared/utils/dateUtils';
 
 // Utilities
 import {
@@ -55,6 +54,7 @@ import {
   getTypeColor,
   parseEditValue,
   serializeForEdit,
+  normalizeEditedValue,
   extractAllFields,
   processDocuments,
   getVisibleFields,
@@ -487,24 +487,8 @@ const CollectionTab: React.FC<CollectionTabProps> = ({ project, collectionPath, 
       const oldValue = editingCell?.originalValue ?? doc.data?.[field];
 
       // Determine the new value - use explicit if provided, otherwise parse editValue
-      let newValue: FirestoreValue;
-      if (explicitValue !== undefined) {
-        newValue = explicitValue;
-      } else {
-        newValue = parseEditValue(editValue);
-
-        // Preserve original type for timestamps
-        if (isFirestoreTimestamp(oldValue) && typeof newValue === 'string' && isIsoDateString(newValue)) {
-          const date = new Date(newValue);
-          newValue = {
-            _seconds: Math.floor(date.getTime() / 1000),
-            _nanoseconds: 0,
-          };
-        } else if (isUnixTimestampMs(oldValue) && typeof newValue === 'string' && isIsoDateString(newValue)) {
-          const date = new Date(newValue);
-          newValue = date.getTime();
-        }
-      }
+      let newValue: FirestoreValue = explicitValue !== undefined ? explicitValue : parseEditValue(editValue);
+      newValue = normalizeEditedValue(newValue, oldValue);
 
       // Skip if unchanged
       if (JSON.stringify(oldValue) === JSON.stringify(newValue)) {

--- a/src/features/collections/components/TableView.tsx
+++ b/src/features/collections/components/TableView.tsx
@@ -86,6 +86,7 @@ const TableView: React.FC<TableViewProps> = ({
   // --- Helpers ---
 
   const shouldUseDialogEditor = (value: FirestoreValue) => {
+    if (isFirestoreTimestamp(value) || value instanceof Date) return false;
     if (Array.isArray(value) || (typeof value === 'object' && value !== null)) return true;
     if (typeof value === 'string') {
       return value.includes('\n') || value.length > LONG_TEXT_THRESHOLD;

--- a/src/features/collections/components/TreeView.tsx
+++ b/src/features/collections/components/TreeView.tsx
@@ -1,33 +1,38 @@
 import React, { useMemo } from 'react';
 import { Table, TableBody, TableCell, TableContainer, TableHead, TableRow, useTheme } from '@mui/material';
 import { FirestoreValue } from '../../../shared/utils/firestoreUtils';
-import { Document } from '../store/collectionSlice';
-import { Project } from '../../projects/store/projectsSlice';
-import { useTreeSubcollections } from '../hooks/useTreeSubcollections';
+import { Document, DocumentData } from '../store/collectionSlice';
 import TreeNodeRow from './tree/TreeNodeRow';
-import { TreeContext, TreeContextValue } from './tree/TreeContext';
+import { TreeContext, TreeContextValue, TreeEditingCell } from './tree/TreeContext';
 
 interface TreeViewProps {
-  project: Project;
-  firestoreDatabaseId?: string;
   collectionPath: string;
   documents: Document[];
   expandedNodes: Record<string, boolean>;
   toggleNode: (path: string) => void;
-  editingCell: { docId: string; field: string } | null;
+  editingCell: TreeEditingCell | null;
   editValue: string;
   setEditValue: (value: string) => void;
-  onCellEdit: (docId: string | null, field: string | null, value: FirestoreValue) => void;
+  onCellEdit: (
+    docId: string | null,
+    field: string | null,
+    value: FirestoreValue,
+    docData?: DocumentData | boolean,
+    docCollectionPath?: string,
+  ) => void;
   onCellSave: () => void;
   onCellKeyDown: (e: React.KeyboardEvent) => void;
   getType: (value: FirestoreValue) => string;
   getTypeColor: (type: string, isDark: boolean) => string;
   formatValue: (value: FirestoreValue, type: string) => string;
+  subcollectionsByDocPath: Record<string, string[]>;
+  documentsByPath: Record<string, Document[]>;
+  ensureSubcollections: (docPath: string) => void;
+  ensureDocuments: (collectionPath: string) => void;
+  refreshDocuments: (collectionPath: string) => void;
 }
 
 const TreeView: React.FC<TreeViewProps> = ({
-  project,
-  firestoreDatabaseId,
   collectionPath,
   documents,
   expandedNodes,
@@ -41,13 +46,14 @@ const TreeView: React.FC<TreeViewProps> = ({
   getType,
   getTypeColor,
   formatValue,
+  subcollectionsByDocPath,
+  documentsByPath,
+  ensureSubcollections,
+  ensureDocuments,
+  refreshDocuments,
 }) => {
   const theme = useTheme();
   const isDark = theme.palette.mode === 'dark';
-  const { subcollectionsByDocPath, documentsByPath, ensureSubcollections, ensureDocuments } = useTreeSubcollections(
-    project,
-    firestoreDatabaseId,
-  );
 
   const contextValue = useMemo<TreeContextValue>(
     () => ({
@@ -69,6 +75,7 @@ const TreeView: React.FC<TreeViewProps> = ({
       documentsByPath,
       ensureSubcollections,
       ensureDocuments,
+      refreshDocuments,
     }),
     [
       collectionPath,
@@ -89,6 +96,7 @@ const TreeView: React.FC<TreeViewProps> = ({
       documentsByPath,
       ensureSubcollections,
       ensureDocuments,
+      refreshDocuments,
     ],
   );
 

--- a/src/features/collections/components/table/CellRenderer.tsx
+++ b/src/features/collections/components/table/CellRenderer.tsx
@@ -5,6 +5,7 @@ import {
   isUnixTimestampMs,
   isIsoDateString,
   formatDateForDisplay,
+  formatDateForDateTimeLocal,
 } from '../../../../shared/utils/dateUtils';
 import { MONOSPACE_FONT_FAMILY } from '../../../../shared/utils/constants';
 import { FirestoreValue } from '../../../../shared/utils/firestoreUtils';
@@ -99,7 +100,7 @@ const CellRenderer: React.FC<CellRendererProps> = ({
         }
 
         if (!isNaN(dateValue.getTime())) {
-          setTempDateValue(dateValue.toISOString().slice(0, 19));
+          setTempDateValue(formatDateForDateTimeLocal(dateValue));
         }
       }
     }

--- a/src/features/collections/components/tree/TreeContext.ts
+++ b/src/features/collections/components/tree/TreeContext.ts
@@ -1,16 +1,31 @@
 import React from 'react';
 import { FirestoreValue } from '../../../../shared/utils/firestoreUtils';
-import { Document } from '../../store/collectionSlice';
+import { Document, DocumentData } from '../../store/collectionSlice';
+
+export interface TreeEditingCell {
+  docId: string;
+  field: string;
+  originalValue?: FirestoreValue;
+  originalType?: string;
+  docData?: DocumentData;
+  docCollectionPath?: string;
+}
 
 export interface TreeContextValue {
   rootPath: string;
   rootDocuments: Document[];
   expandedNodes: Record<string, boolean>;
   toggleNode: (path: string) => void;
-  editingCell: { docId: string; field: string } | null;
+  editingCell: TreeEditingCell | null;
   editValue: string;
   setEditValue: (value: string) => void;
-  onCellEdit: (docId: string | null, field: string | null, value: FirestoreValue) => void;
+  onCellEdit: (
+    docId: string | null,
+    field: string | null,
+    value: FirestoreValue,
+    docData?: DocumentData | boolean,
+    docCollectionPath?: string,
+  ) => void;
   onCellSave: () => void;
   onCellKeyDown: (e: React.KeyboardEvent) => void;
   getType: (value: FirestoreValue) => string;
@@ -21,6 +36,7 @@ export interface TreeContextValue {
   documentsByPath: Record<string, Document[]>;
   ensureSubcollections: (docPath: string) => void;
   ensureDocuments: (collectionPath: string) => void;
+  refreshDocuments: (collectionPath: string) => void;
 }
 
 export const TreeContext = React.createContext<TreeContextValue | null>(null);

--- a/src/features/collections/components/tree/TreeNodeRow.tsx
+++ b/src/features/collections/components/tree/TreeNodeRow.tsx
@@ -12,6 +12,7 @@ import {
   isUnixTimestampMs,
   formatDateForDateTimeLocal,
 } from '../../../../shared/utils/dateUtils';
+import { DocumentData } from '../../store/collectionSlice';
 import { TreeContext } from './TreeContext';
 
 interface TreeNodeRowProps {
@@ -19,6 +20,8 @@ interface TreeNodeRowProps {
   value: FirestoreValue;
   path: string;
   docId?: string;
+  docData?: DocumentData;
+  docCollectionPath?: string;
   depth?: number;
   isDoc?: boolean;
   isCollection?: boolean;
@@ -30,6 +33,8 @@ const TreeNodeRow: React.FC<TreeNodeRowProps> = ({
   value,
   path,
   docId,
+  docData,
+  docCollectionPath,
   depth = 0,
   isDoc = false,
   isCollection = false,
@@ -63,7 +68,12 @@ const TreeNodeRow: React.FC<TreeNodeRowProps> = ({
   const isExpanded = expandedNodes[path];
   const displayValue = isExpandable ? '' : formatValue(value, nodeType);
   const isEditing =
-    !isCollection && !isDoc && !isExpandable && editingCell?.docId === docId && editingCell?.field === nodeKey;
+    !isCollection &&
+    !isDoc &&
+    !isExpandable &&
+    editingCell?.docId === docId &&
+    editingCell?.field === nodeKey &&
+    (editingCell?.docCollectionPath ?? docCollectionPath) === docCollectionPath;
   const isDateLike = nodeType === 'Timestamp' || isFirestoreTimestamp(value) || isUnixTimestampMs(value);
 
   const [dateValue, setDateValue] = React.useState('');
@@ -167,7 +177,7 @@ const TreeNodeRow: React.FC<TreeNodeRowProps> = ({
               )
             ) : (
               <Typography
-                onClick={() => docId && onCellEdit(docId, nodeKey, value)}
+                onClick={() => docId && onCellEdit(docId, nodeKey, value, docData, docCollectionPath)}
                 sx={{
                   fontSize: '0.8rem',
                   color: getTypeColor(nodeType, isDark),
@@ -205,7 +215,9 @@ const TreeNodeRow: React.FC<TreeNodeRowProps> = ({
                 nodeKey={doc.id}
                 value={doc.data}
                 path={`${path}/${doc.id}`}
-                docId={isRoot ? doc.id : undefined}
+                docId={doc.id}
+                docData={doc.data}
+                docCollectionPath={path}
                 isDoc
                 depth={depth + 1}
                 missing={doc.missing}
@@ -224,6 +236,8 @@ const TreeNodeRow: React.FC<TreeNodeRowProps> = ({
                 value={v}
                 path={`${path}.${k}`}
                 docId={docId}
+                docData={docData}
+                docCollectionPath={docCollectionPath}
                 depth={depth + 1}
               />
             ))}
@@ -239,6 +253,8 @@ const TreeNodeRow: React.FC<TreeNodeRowProps> = ({
                     value={v}
                     path={`${path}.${k}`}
                     docId={docId}
+                    docData={docData}
+                    docCollectionPath={docCollectionPath}
                     depth={depth + 1}
                   />
                 ))}

--- a/src/features/collections/components/tree/TreeNodeRow.tsx
+++ b/src/features/collections/components/tree/TreeNodeRow.tsx
@@ -7,6 +7,11 @@ import {
   Description as DocumentIcon,
 } from '@mui/icons-material';
 import { FirestoreValue } from '../../../../shared/utils/firestoreUtils';
+import {
+  isFirestoreTimestamp,
+  isUnixTimestampMs,
+  formatDateForDateTimeLocal,
+} from '../../../../shared/utils/dateUtils';
 import { TreeContext } from './TreeContext';
 
 interface TreeNodeRowProps {
@@ -59,6 +64,15 @@ const TreeNodeRow: React.FC<TreeNodeRowProps> = ({
   const displayValue = isExpandable ? '' : formatValue(value, nodeType);
   const isEditing =
     !isCollection && !isDoc && !isExpandable && editingCell?.docId === docId && editingCell?.field === nodeKey;
+  const isDateLike = nodeType === 'Timestamp' || isFirestoreTimestamp(value) || isUnixTimestampMs(value);
+
+  const [dateValue, setDateValue] = React.useState('');
+
+  useEffect(() => {
+    if (isEditing && isDateLike) {
+      setDateValue(formatDateForDateTimeLocal(value));
+    }
+  }, [isEditing, isDateLike, value]);
 
   const isRoot = isCollection && path === rootPath;
   const collectionDocs = isCollection ? (isRoot ? rootDocuments : documentsByPath[path]) : undefined;
@@ -113,21 +127,44 @@ const TreeNodeRow: React.FC<TreeNodeRowProps> = ({
         <TableCell sx={{ py: 0.25, borderBottom: 1, borderColor: 'divider', width: '40%' }}>
           {!isCollection && !isDoc && !isExpandable ? (
             isEditing ? (
-              <TextField
-                size="small"
-                value={editValue}
-                onChange={(e) => setEditValue(e.target.value)}
-                onBlur={onCellSave}
-                onKeyDown={onCellKeyDown}
-                autoFocus
-                sx={{
-                  '& .MuiInputBase-input': {
-                    fontFamily: 'monospace',
-                    fontSize: '0.8rem',
-                    py: 0.5,
-                  },
-                }}
-              />
+              isDateLike ? (
+                <TextField
+                  type="datetime-local"
+                  size="small"
+                  value={dateValue}
+                  onChange={(e) => {
+                    setDateValue(e.target.value);
+                    setEditValue(e.target.value);
+                  }}
+                  onBlur={onCellSave}
+                  onKeyDown={onCellKeyDown}
+                  autoFocus
+                  InputLabelProps={{ shrink: true }}
+                  sx={{
+                    '& .MuiInputBase-input': {
+                      fontFamily: 'monospace',
+                      fontSize: '0.8rem',
+                      py: 0.5,
+                    },
+                  }}
+                />
+              ) : (
+                <TextField
+                  size="small"
+                  value={editValue}
+                  onChange={(e) => setEditValue(e.target.value)}
+                  onBlur={onCellSave}
+                  onKeyDown={onCellKeyDown}
+                  autoFocus
+                  sx={{
+                    '& .MuiInputBase-input': {
+                      fontFamily: 'monospace',
+                      fontSize: '0.8rem',
+                      py: 0.5,
+                    },
+                  }}
+                />
+              )
             ) : (
               <Typography
                 onClick={() => docId && onCellEdit(docId, nodeKey, value)}

--- a/src/features/collections/hooks/useTreeSubcollections.ts
+++ b/src/features/collections/hooks/useTreeSubcollections.ts
@@ -11,6 +11,7 @@ export interface TreeSubcollections {
   documentsByPath: Record<string, Document[]>;
   ensureSubcollections: (docPath: string) => void;
   ensureDocuments: (collectionPath: string) => void;
+  refreshDocuments: (collectionPath: string) => void;
 }
 
 export function useTreeSubcollections(project: Project, firestoreDatabaseId?: string): TreeSubcollections {
@@ -66,5 +67,13 @@ export function useTreeSubcollections(project: Project, firestoreDatabaseId?: st
     [isGoogle, project.projectId, databaseId],
   );
 
-  return { subcollectionsByDocPath, documentsByPath, ensureSubcollections, ensureDocuments };
+  const refreshDocuments = useCallback(
+    async (collectionPath: string) => {
+      requestedPaths.current.delete(`col:${collectionPath}`);
+      await ensureDocuments(collectionPath);
+    },
+    [ensureDocuments],
+  );
+
+  return { subcollectionsByDocPath, documentsByPath, ensureSubcollections, ensureDocuments, refreshDocuments };
 }

--- a/src/shared/utils/dateUtils.test.ts
+++ b/src/shared/utils/dateUtils.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { isDateTimeLocalString, formatDateForDateTimeLocal } from './dateUtils';
+
+const toLocalDateTimeString = (date: Date): string => {
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}`;
+};
+
+describe('isDateTimeLocalString', () => {
+  it('accepts datetime-local strings with and without seconds', () => {
+    expect(isDateTimeLocalString('2024-01-15T10:30')).toBe(true);
+    expect(isDateTimeLocalString('2024-01-15T10:30:00')).toBe(true);
+  });
+
+  it('rejects ISO strings with timezone and non-dates', () => {
+    expect(isDateTimeLocalString('2024-01-15T10:30:00.000Z')).toBe(false);
+    expect(isDateTimeLocalString('2024-01-15')).toBe(false);
+    expect(isDateTimeLocalString('not a date')).toBe(false);
+    expect(isDateTimeLocalString(123)).toBe(false);
+  });
+});
+
+describe('formatDateForDateTimeLocal', () => {
+  it('formats a Firestore timestamp in local time', () => {
+    const expected = toLocalDateTimeString(new Date(1767225600 * 1000));
+    expect(formatDateForDateTimeLocal({ _seconds: 1767225600, _nanoseconds: 0 })).toBe(expected);
+  });
+
+  it('formats a Unix timestamp in ms and an ISO string', () => {
+    expect(formatDateForDateTimeLocal(1767225600000)).toBe(toLocalDateTimeString(new Date(1767225600000)));
+    expect(formatDateForDateTimeLocal('2024-01-15T10:30:00.000Z')).toBe(
+      toLocalDateTimeString(new Date('2024-01-15T10:30:00.000Z')),
+    );
+  });
+
+  it('round-trips through new Date without an offset shift', () => {
+    const formatted = formatDateForDateTimeLocal({ _seconds: 1767225600, _nanoseconds: 0 });
+    expect(new Date(formatted).getTime()).toBe(1767225600 * 1000);
+  });
+
+  it('returns an empty string for invalid values', () => {
+    expect(formatDateForDateTimeLocal('garbage')).toBe('');
+    expect(formatDateForDateTimeLocal(null)).toBe('');
+  });
+});

--- a/src/shared/utils/dateUtils.ts
+++ b/src/shared/utils/dateUtils.ts
@@ -21,6 +21,15 @@ export const isUnixTimestampMs = (value: unknown): value is number => {
   return value > 946684800000 && value < 4102444800000;
 };
 
+/**
+ * Checks if a value is a datetime-local string (no timezone, as emitted by
+ * <input type="datetime-local">). Example: 2024-01-15T10:30 or 2024-01-15T10:30:00
+ */
+export const isDateTimeLocalString = (value: unknown): value is string => {
+  if (typeof value !== 'string') return false;
+  return /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(:\d{2})?$/.test(value);
+};
+
 interface FirestoreTimestamp {
   _seconds?: number;
   seconds?: number;
@@ -78,4 +87,17 @@ export const formatDateForDisplay = (value: unknown, format: 'locale' | 'iso' | 
   if (format === 'time') return date.toLocaleTimeString();
 
   return date.toLocaleString();
+};
+
+const pad2 = (n: number) => String(n).padStart(2, '0');
+
+/**
+ * Formats a date value for a <input type="datetime-local"> field.
+ * Uses LOCAL time: datetime-local strings are parsed back as local time,
+ * so this round-trips without a timezone offset shift.
+ */
+export const formatDateForDateTimeLocal = (value: unknown): string => {
+  const date = toDate(value);
+  if (!date || isNaN(date.getTime())) return '';
+  return `${date.getFullYear()}-${pad2(date.getMonth() + 1)}-${pad2(date.getDate())}T${pad2(date.getHours())}:${pad2(date.getMinutes())}:${pad2(date.getSeconds())}`;
 };

--- a/src/shared/utils/firestoreUtils.test.ts
+++ b/src/shared/utils/firestoreUtils.test.ts
@@ -43,6 +43,22 @@ describe('normalizeEditedValue', () => {
     expect(normalizeEditedValue('hello', { _seconds: 1767225600, _nanoseconds: 0 })).toBe('hello');
   });
 
+  it('converts a datetime-local string back to a timestamp when the original was a Firestore timestamp', () => {
+    const date = new Date('2024-01-15T10:30');
+    expect(normalizeEditedValue('2024-01-15T10:30', { _seconds: 1767225600, _nanoseconds: 0 })).toEqual({
+      _seconds: Math.floor(date.getTime() / 1000),
+      _nanoseconds: 0,
+    });
+  });
+
+  it('converts a datetime-local string back to Unix ms when the original was one', () => {
+    expect(normalizeEditedValue('2024-01-15T10:30:00', 1767225600000)).toBe(new Date('2024-01-15T10:30:00').getTime());
+  });
+
+  it('leaves a datetime-local string unchanged when the original was a string', () => {
+    expect(normalizeEditedValue('2024-01-15T10:30', 'hello')).toBe('2024-01-15T10:30');
+  });
+
   it('passes explicit timestamp objects through unchanged', () => {
     const value = { _seconds: 1767225600, _nanoseconds: 0 };
     expect(normalizeEditedValue(value, value)).toBe(value);

--- a/src/shared/utils/firestoreUtils.test.ts
+++ b/src/shared/utils/firestoreUtils.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { serializeForEdit, normalizeEditedValue } from './firestoreUtils';
+
+describe('serializeForEdit', () => {
+  it('serializes a Firestore timestamp to an ISO date string', () => {
+    expect(serializeForEdit({ _seconds: 1767225600, _nanoseconds: 0 }, 'Timestamp')).toBe('2026-01-01T00:00:00.000Z');
+  });
+
+  it('serializes a Date instance to an ISO date string', () => {
+    expect(serializeForEdit(new Date('2026-01-01T00:00:00.000Z'), 'Timestamp')).toBe('2026-01-01T00:00:00.000Z');
+  });
+
+  it('does not stringify objects to [object Object]', () => {
+    expect(serializeForEdit({ _seconds: 1767225600 }, 'Timestamp')).not.toContain('[object Object]');
+  });
+
+  it('keeps arrays and maps as JSON', () => {
+    expect(serializeForEdit({ a: 1 }, 'Map')).toBe('{\n  "a": 1\n}');
+    expect(serializeForEdit([1, 2], 'Array')).toBe('[\n  1,\n  2\n]');
+  });
+
+  it('keeps null and undefined', () => {
+    expect(serializeForEdit(null, 'Null')).toBe('null');
+    expect(serializeForEdit(undefined, 'Undefined')).toBe('');
+  });
+});
+
+describe('normalizeEditedValue', () => {
+  it('converts an ISO string back to a timestamp when the original was a Firestore timestamp', () => {
+    const result = normalizeEditedValue('2026-01-01T00:00:00.000Z', { _seconds: 1767225600, _nanoseconds: 0 });
+    expect(result).toEqual({ _seconds: 1767225600, _nanoseconds: 0 });
+  });
+
+  it('converts an ISO string back to a Unix timestamp in ms when the original was one', () => {
+    expect(normalizeEditedValue('2026-01-01T00:00:00.000Z', 1767225600000)).toBe(1767225600000);
+  });
+
+  it('leaves an ISO string unchanged when the original was a string', () => {
+    expect(normalizeEditedValue('2026-01-01T00:00:00.000Z', 'hello')).toBe('2026-01-01T00:00:00.000Z');
+  });
+
+  it('leaves a non-ISO string unchanged when the original was a timestamp', () => {
+    expect(normalizeEditedValue('hello', { _seconds: 1767225600, _nanoseconds: 0 })).toBe('hello');
+  });
+
+  it('passes explicit timestamp objects through unchanged', () => {
+    const value = { _seconds: 1767225600, _nanoseconds: 0 };
+    expect(normalizeEditedValue(value, value)).toBe(value);
+  });
+});

--- a/src/shared/utils/firestoreUtils.ts
+++ b/src/shared/utils/firestoreUtils.ts
@@ -2,7 +2,13 @@
  * Firestore Data Type Utilities
  * Handles type detection, formatting, and value parsing for Firestore documents
  */
-import { formatDateForDisplay, isFirestoreTimestamp, isIsoDateString, isUnixTimestampMs } from './dateUtils';
+import {
+  formatDateForDisplay,
+  isDateTimeLocalString,
+  isFirestoreTimestamp,
+  isIsoDateString,
+  isUnixTimestampMs,
+} from './dateUtils';
 
 // Firestore value types
 export type FirestoreValue =
@@ -244,7 +250,7 @@ export const serializeForEdit = (value: FirestoreValue, type: string): string =>
  * original value was a Firestore timestamp or a Unix timestamp in ms.
  */
 export const normalizeEditedValue = (newValue: FirestoreValue, oldValue: FirestoreValue): FirestoreValue => {
-  if (typeof newValue === 'string' && isIsoDateString(newValue)) {
+  if (typeof newValue === 'string' && (isIsoDateString(newValue) || isDateTimeLocalString(newValue))) {
     if (isFirestoreTimestamp(oldValue)) {
       const date = new Date(newValue);
       return { _seconds: Math.floor(date.getTime() / 1000), _nanoseconds: 0 };

--- a/src/shared/utils/firestoreUtils.ts
+++ b/src/shared/utils/firestoreUtils.ts
@@ -2,6 +2,7 @@
  * Firestore Data Type Utilities
  * Handles type detection, formatting, and value parsing for Firestore documents
  */
+import { formatDateForDisplay, isFirestoreTimestamp, isIsoDateString, isUnixTimestampMs } from './dateUtils';
 
 // Firestore value types
 export type FirestoreValue =
@@ -229,7 +230,28 @@ export const serializeForEdit = (value: FirestoreValue, type: string): string =>
   if (type === 'Array' || type === 'Map') {
     return JSON.stringify(value, null, 2);
   }
+  if (type === 'Timestamp') {
+    return formatDateForDisplay(value, 'iso');
+  }
   if (value === undefined) return '';
   if (value === null) return 'null';
   return String(value);
+};
+
+/**
+ * Preserves the original field type when an edited ISO date string is saved.
+ * Only applies when the edited value is a valid ISO date string and the
+ * original value was a Firestore timestamp or a Unix timestamp in ms.
+ */
+export const normalizeEditedValue = (newValue: FirestoreValue, oldValue: FirestoreValue): FirestoreValue => {
+  if (typeof newValue === 'string' && isIsoDateString(newValue)) {
+    if (isFirestoreTimestamp(oldValue)) {
+      const date = new Date(newValue);
+      return { _seconds: Math.floor(date.getTime() / 1000), _nanoseconds: 0 };
+    }
+    if (isUnixTimestampMs(oldValue)) {
+      return new Date(newValue).getTime();
+    }
+  }
+  return newValue;
 };

--- a/src/shared/utils/index.ts
+++ b/src/shared/utils/index.ts
@@ -15,6 +15,7 @@ export {
   parseFirestoreValue,
   parseEditValue,
   serializeForEdit,
+  normalizeEditedValue,
 } from './firestoreUtils';
 
 // Query parsing and building utilities


### PR DESCRIPTION
## Summary

### 1. Fix IPC serialization of Firestore references and timestamps

- Fixes `Error: An object could not be cloned` thrown by the `firestore:getDocuments` and `firestore:executeJsQuery` IPC handlers whenever a document contains a Firestore reference field (e.g. `programRef`, `createdByRef`).
- Root cause: `@google-cloud/firestore` v7 `doc.data()` decodes `referenceValue` fields into `DocumentReference` instances that hold the entire Firestore client (including gRPC connection pools). Electron's structured clone cannot serialize those instances across the IPC boundary, so reading such a document fails entirely.
- Fix: decode documents via `parseFirestoreDocument(doc._fieldsProto)` instead of `doc.data()` so references, timestamps and geopoints cross IPC as plain values — the same representation the Google REST (`googleController`) path already produces.
- Follow-up: `_fieldsProto` is the raw gRPC binary proto, where `timestampValue` is a `{ seconds, nanos }` object — not the RFC3339 string used by the REST JSON path. The decoder now handles both shapes, so timestamps always arrive as valid `{ _seconds, _nanoseconds }` and never crash the tree view with `RangeError: Invalid time value`.

### 2. Fix timestamp type corruption when editing fields

- Editing a timestamp field previously changed its type to String and saved `[object Object]`. Two renderer paths caused it:
  - `serializeForEdit` had no `Timestamp` branch, so it fell through to `String(value)`.
  - The table-view dialog passed an ISO string as `explicitValue`, bypassing the type-preservation guard in `handleCellSave`.
- Fix: `serializeForEdit` now emits the ISO date string for timestamps, and a new `normalizeEditedValue` helper converts an edited ISO string back to a Firestore timestamp (`{ _seconds, _nanoseconds }`) or Unix ms when the original value was a timestamp. Both save paths use it.

### 3. Edit timestamp fields with a date-time picker

- All timestamp edits now go through a native `datetime-local` selector matching the existing UI: the table's inline `DatePopover` already used one, and now it also opens on double-click (previously double-clicking a timestamp opened a plain-text JSON editor), and the tree view uses a `datetime-local` field instead of an ISO text input.
- New helpers in `dateUtils`: `isDateTimeLocalString` and `formatDateForDateTimeLocal`. The picker shows **local** time, so saving round-trips without a timezone offset shift (previously the table popover displayed UTC and re-parsed the value as local, silently shifting the instant).
- `normalizeEditedValue` also accepts the `datetime-local` format, so edited values keep their Timestamp type on save.

### 4. Edit subcollection documents in the tree view

- Documents inside subcollections (and nested sub-subcollections, recursively) could not be edited: `TreeNodeRow` only assigned a `docId` to root-collection documents, so nested rows had no click handler, never entered edit mode, and the save handler looked the doc up in the root collection and always wrote to `rootCollection/docId`.
- Fix: every document row now carries its `docId`, a snapshot of its `docData` and its `docCollectionPath`. `handleCellSave` writes to that collection path (arbitrary nested paths were already supported by `setDocument`/`googleSetDocument`) and refreshes the nested collection after a successful save (nested docs live in hook state, not Redux, so they were otherwise never re-rendered).
- Edit identity now also matches `docCollectionPath`, so two documents with the same `id` in different subcollections no longer enter edit mode simultaneously.
- `useTreeSubcollections` grew a `refreshDocuments` helper that clears the request-dedupe cache and re-fetches a nested collection; the hook was lifted from `TreeView` into `CollectionTab` so saves can reach it.

## Changes

| File | Change |
|------|--------|
| `electron/utils/firestoreHelpers.js` | Added `firestoreDocumentToData(doc)` helper — decodes `doc._fieldsProto` into plain cloneable data via the existing `parseFirestoreDocument`. `parseFirestoreValue` now accepts both RFC3339 string and `{ seconds, nanos }` proto timestamps. |
| `electron/controllers/firestoreController.js` | Replaced `doc.data()` with `firestoreDocumentToData(doc)` in `getDocument`, `query`, `exportCollection`, `exportCollections` and `executeJsQuery`. |
| `electron/controllers/firestore/documentList.js` | Replaced `doc.data()` with `firestoreDocumentToData(doc)` in `toDocumentEntry` (used by `getDocuments`, including phantom-doc pagination). |
| `electron/controllers/firestoreController.test.js` | Regression tests: `referenceValue` field returned as a plain string, gRPC proto timestamp `{ seconds, nanos }` decoded to `{ _seconds, _nanoseconds }`, and RFC3339 string timestamps handled too. |
| `src/shared/utils/firestoreUtils.ts` | `serializeForEdit` emits ISO strings for `Timestamp` type; `normalizeEditedValue` preserves the original timestamp type on save and now also accepts `datetime-local` strings. |
| `src/shared/utils/dateUtils.ts` | New `isDateTimeLocalString` and `formatDateForDateTimeLocal` (local-time) helpers. |
| `src/shared/utils/index.ts` | Re-exports `normalizeEditedValue`. |
| `src/features/collections/components/CollectionTab.tsx` | `handleCellSave` runs `normalizeEditedValue` on both edit paths; now saves nested docs to their own collection path and refreshes the nested collection; owns `useTreeSubcollections` (lifted from `TreeView`). |
| `src/features/collections/components/TableView.tsx` | Double-click on a timestamp now opens the date picker instead of the JSON editor (`shouldUseDialogEditor` excludes timestamps and `Date`). |
| `src/features/collections/components/table/CellRenderer.tsx` | Popover initial value uses local time via `formatDateForDateTimeLocal` (no more UTC display / offset shift on save). |
| `src/features/collections/components/tree/TreeNodeRow.tsx` | Date-like values are edited with a `TextField type="datetime-local"`; every document row now carries `docId`/`docData`/`docCollectionPath`, and edit identity includes the collection path (subcollection docs are editable). |
| `src/features/collections/components/tree/TreeContext.ts` | `TreeEditingCell` type (adds `docData`/`docCollectionPath`); `onCellEdit` and context gain `refreshDocuments`. |
| `src/features/collections/components/TreeView.tsx` | Receives subcollection data + `refreshDocuments` as props instead of owning the hook. |
| `src/features/collections/hooks/useTreeSubcollections.ts` | New `refreshDocuments` that clears the dedupe cache and re-fetches a nested collection. |
| `src/shared/utils/firestoreUtils.test.ts` | New tests for `serializeForEdit` and `normalizeEditedValue` (ISO + datetime-local inputs). |
| `src/shared/utils/dateUtils.test.ts` | New tests for `isDateTimeLocalString` and `formatDateForDateTimeLocal`. |

## Behavior notes

- References are returned as their full path string (e.g. `projects/ucg-learn/databases/(default)/documents/programs/QJjj...`), matching the Google auth method output.
- Timestamps keep the same `{ _seconds, _nanoseconds }` shape the renderer already understands, from both the admin SDK and REST sources.
- As with the Google path, a reference is persisted back as a plain string if the document is edited and saved — not re-encoded as a Firestore reference.
- Editing a timestamp field keeps its Timestamp type after save; the value round-trips through the `datetime-local` selector in local time.
- Subcollection documents (any depth) are edited exactly like root documents and written to their full document path.

## Test plan

- [x] `vitest run` — 82 tests pass (14 electron controller, 19 firestore/date utils, rest of the suite)
- [x] lint-staged (eslint + prettier) passes on all changed files
- [x] `tsc -p tsconfig.json --noEmit` passes
