### PR TITLE
fix(tests): provide localStorage shim in jsdom test setup

### DIFF
--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,3 +1,43 @@
+// jsdom does not reliably expose `localStorage` across environments (e.g. on
+// Node 26 its experimental built-in `localStorage` shadows the jsdom one, so
+// `localStorage` is undefined in tests). Provide a minimal in-memory shim so
+// tests that rely on `localStorage` run consistently regardless of the runtime.
+if (typeof globalThis.localStorage === 'undefined') {
+  class MemoryStorage {
+    private store = new Map<string, string>();
+
+    get length(): number {
+      return this.store.size;
+    }
+
+    key(index: number): string | null {
+      return Array.from(this.store.keys())[index] ?? null;
+    }
+
+    getItem(key: string): string | null {
+      return this.store.get(key) ?? null;
+    }
+
+    setItem(key: string, value: string): void {
+      this.store.set(key, String(value));
+    }
+
+    removeItem(key: string): void {
+      this.store.delete(key);
+    }
+
+    clear(): void {
+      this.store.clear();
+    }
+  }
+
+  const storage = new MemoryStorage();
+  globalThis.localStorage = storage as unknown as Storage;
+  if (typeof window !== 'undefined') {
+    window.localStorage = storage as unknown as Storage;
+  }
+}
+
 beforeEach(() => {
   if (typeof localStorage !== 'undefined') {
     localStorage.clear();


### PR DESCRIPTION
## Summary
`projectsPersistence.test.ts` and `projectsSlice.test.ts` were failing with `TypeError: Cannot read properties of undefined (reading 'getItem')` because `localStorage` was undefined in the test environment. This adds a minimal, guarded in-memory `localStorage` shim to `src/test/setup.ts` so tests pass consistently regardless of runtime.

## Root cause
The repo's vitest config uses `environment: 'jsdom'`, which normally exposes `localStorage`. However, on runtimes where jsdom does not reliably expose it (e.g. Node 26's experimental built-in `localStorage` shadows the jsdom one, emitting `localStorage is not available because --localstorage-file was not provided`), `localStorage` ends up `undefined`, breaking any test that reads/writes project state via `localStorage`.

## Fix
In `src/test/setup.ts`, detect a missing `localStorage` and install an in-memory `Storage` shim on both `globalThis` and `window`. The shim is guarded by a `typeof` check, so it only applies when absent — behavior is unchanged on environments where jsdom already provides `localStorage`. The existing `beforeEach` cleanup is preserved.

## Testing
- `pnpm run test` → 61 passed (was 54 passed / 7 failed before the fix)
- `pnpm run lint`, `pnpm run format:check`, `pnpm run typecheck` → all pass

## Scope
Single-file change (`src/test/setup.ts`). No application/runtime code is affected; it only touches the test environment.
