### PR TITLE
feat: discover Firebase Emulator from FIRESTORE_EMULATOR_HOST env vars

### DIFF
--- a/electron/controllers/emulatorController.js
+++ b/electron/controllers/emulatorController.js
@@ -25,6 +25,78 @@ function readJsonSafely(filePath) {
 }
 
 /**
+ * Normalizes a host that is not directly reachable from a client.
+ * Emulators bind to 0.0.0.0 (IPv4) or [::] (IPv6) by default and report those
+ * addresses back via the environment. Browsers (and some runtimes) cannot
+ * connect to 0.0.0.0 / [::] as a destination, which breaks discovery on macOS
+ * in particular. Map those wildcard addresses to the loopback interface.
+ */
+function normalizeHost(host) {
+  if (!host) return host;
+  if (host === '0.0.0.0') return '127.0.0.1';
+  if (host === '[::]' || host === '::' || host === '::1' || host === '[::1]') return '127.0.0.1';
+  return host;
+}
+
+/**
+ * Best-effort project ID guess for emulators discovered via environment
+ * variables (which do not carry a project ID). Reads .firebaserc by walking up
+ * from the current directory, then falls back to Firebase's conventional
+ * emulator placeholder.
+ */
+function readProjectIdGuess() {
+  let dir = process.cwd();
+  for (let i = 0; i < 12; i++) {
+    const rc = readJsonSafely(path.join(dir, '.firebaserc'));
+    if (rc && rc.projects) {
+      const id = rc.projects.default || Object.keys(rc.projects)[0];
+      if (id) return id;
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return 'demo-project';
+}
+
+/**
+ * Parses a host:port string, normalizing the host. Returns null if malformed.
+ */
+function parseHostPort(value) {
+  if (!value) return null;
+  const idx = value.lastIndexOf(':');
+  if (idx === -1) return null;
+  const host = normalizeHost(value.slice(0, idx)) || '127.0.0.1';
+  const port = parseInt(value.slice(idx + 1), 10);
+  if (!Number.isFinite(port)) return null;
+  return { host, port };
+}
+
+/**
+ * Discovers emulators from standard Firebase Emulator environment variables
+ * (FIRESTORE_EMULATOR_HOST, FIREBASE_AUTH_EMULATOR_HOST,
+ * FIREBASE_STORAGE_EMULATOR_HOST). These are exported by the Emulator Suite and
+ * are an authoritative signal of a running emulator.
+ */
+function scanEnv() {
+  const firestore = parseHostPort(process.env.FIRESTORE_EMULATOR_HOST);
+  if (!firestore) return null;
+
+  const services = { firestore };
+  const auth = parseHostPort(process.env.FIREBASE_AUTH_EMULATOR_HOST);
+  if (auth) services.auth = auth;
+  const storage = parseHostPort(process.env.FIREBASE_STORAGE_EMULATOR_HOST);
+  if (storage) services.storage = storage;
+
+  return {
+    projectId: readProjectIdGuess(),
+    host: firestore.host,
+    port: firestore.port,
+    services,
+  };
+}
+
+/**
  * Scans the OS temp directory for running emulator hub files.
  * The hub locator file (hub-<projectId>.json) only contains version, origins, and pid.
  * To get the running emulator services, we must fetch GET /emulators from the hub.
@@ -86,6 +158,30 @@ async function scanHubFiles() {
 }
 
 /**
+ * Merges all discovery strategies (hub locator files and environment
+ * variables), de-duplicating by Firestore host:port so a single running
+ * emulator is not reported multiple times.
+ */
+async function scanRunningEmulators() {
+  const results = [];
+  const seen = new Set();
+  const add = (emulator) => {
+    if (!emulator) return;
+    const key = `${emulator.host}:${emulator.port}`;
+    if (seen.has(key)) return;
+    seen.add(key);
+    results.push(emulator);
+  };
+
+  const fromFiles = await scanHubFiles();
+  fromFiles.forEach(add);
+
+  add(scanEnv());
+
+  return results;
+}
+
+/**
  * Scans the Firebase CLI configstore to map project IDs to local paths
  */
 function scanConfigstore() {
@@ -116,10 +212,10 @@ function scanConfigstore() {
  * Registers all Emulator IPC handlers
  */
 function registerHandlers() {
-  // Scans for running emulators via hub files
+  // Scans for running emulators via hub files and environment variables
   ipcMain.handle('emulators:scanHub', async () => {
     try {
-      const emulators = await scanHubFiles();
+      const emulators = await scanRunningEmulators();
       return { success: true, emulators };
     } catch (err) {
       return { success: false, error: err.message };
@@ -139,4 +235,5 @@ function registerHandlers() {
 
 module.exports = {
   registerHandlers,
+  scanRunningEmulators,
 };

--- a/electron/controllers/emulatorController.js
+++ b/electron/controllers/emulatorController.js
@@ -45,6 +45,13 @@ function normalizeHost(host) {
  * emulator placeholder.
  */
 function readProjectIdGuess() {
+  // Honor the project id the emulator was started with. The gcloud Firestore
+  // emulator (and the Firebase Emulator Suite) advertise it via these vars;
+  // without this, discovery falls back to the generic `demo-project` and the
+  // connection's project id won't match the emulator's, returning no data.
+  const envProject = process.env.FIRESTORE_EMULATOR_PROJECT || process.env.GCLOUD_PROJECT;
+  if (envProject) return envProject;
+
   let dir = process.cwd();
   for (let i = 0; i < 12; i++) {
     const rc = readJsonSafely(path.join(dir, '.firebaserc'));

--- a/electron/controllers/emulatorController.js
+++ b/electron/controllers/emulatorController.js
@@ -33,6 +33,9 @@ function readJsonSafely(filePath) {
  */
 function normalizeHost(host) {
   if (!host) return host;
+  // `localhost` resolves to IPv6 `::1` for gRPC clients and can hang/fail to
+  // connect; route it to the IPv4 loopback, which emulators reliably serve.
+  if (host === 'localhost') return '127.0.0.1';
   if (host === '0.0.0.0') return '127.0.0.1';
   if (host === '[::]' || host === '::' || host === '::1' || host === '[::1]') return '127.0.0.1';
   return host;

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,3 +1,43 @@
+// jsdom does not reliably expose `localStorage` across environments (e.g. on
+// Node 26 its experimental built-in `localStorage` shadows the jsdom one, so
+// `localStorage` is undefined in tests). Provide a minimal in-memory shim so
+// tests that rely on `localStorage` run consistently regardless of the runtime.
+if (typeof globalThis.localStorage === 'undefined') {
+  class MemoryStorage {
+    private store = new Map<string, string>();
+
+    get length(): number {
+      return this.store.size;
+    }
+
+    key(index: number): string | null {
+      return Array.from(this.store.keys())[index] ?? null;
+    }
+
+    getItem(key: string): string | null {
+      return this.store.get(key) ?? null;
+    }
+
+    setItem(key: string, value: string): void {
+      this.store.set(key, String(value));
+    }
+
+    removeItem(key: string): void {
+      this.store.delete(key);
+    }
+
+    clear(): void {
+      this.store.clear();
+    }
+  }
+
+  const storage = new MemoryStorage();
+  globalThis.localStorage = storage as unknown as Storage;
+  if (typeof window !== 'undefined') {
+    window.localStorage = storage as unknown as Storage;
+  }
+}
+
 beforeEach(() => {
   if (typeof localStorage !== 'undefined') {
     localStorage.clear();


### PR DESCRIPTION
## Summary
FireStudio now discovers a locally running emulator via the standard Emulator Suite environment variables (`FIRESTORE_EMULATOR_HOST`, `FIREBASE_AUTH_EMULATOR_HOST`, `FIREBASE_STORAGE_EMULATOR_HOST`), in addition to the existing hub-locator-file scan. This makes discovery work even when the Emulator Hub (port 4400) is not running — e.g. `firebase emulators:start --only firestore`, or the `gcloud` Firestore emulator.

It also derives the project ID from `FIRESTORE_EMULATOR_PROJECT` / `GCLOUD_PROJECT`, and normalizes `localhost` (and wildcard bind addresses) to `127.0.0.1` so clients connect reliably over IPv4.

## Problem
Previously, emulator discovery only read the hub locator file `hub-<projectId>.json` from `os.tmpdir()`, which is only written when the Emulator Hub is up. Consequences:
- When a user starts just Firestore (`--only firestore`, or the `gcloud` Firestore emulator), the hub file is absent and `FIRESTORE_EMULATOR_HOST` was never picked up — FireStudio reported no running emulator.
- The discovered project ID fell back to the generic `demo-project`, so even when connected, requests targeted the wrong project and returned no data.
- Hosts like `localhost` resolve to IPv6 `::1` for gRPC clients and can hang/fail to connect; only `127.0.0.1` connects reliably.

## Fix
In `electron/controllers/emulatorController.js`:
- `scanEnv()` — discovers emulators from the standard env vars (authoritative signal of a running emulator) and maps them to a normalized emulator descriptor.
- `parseHostPort()` / `normalizeHost()` — parses `host:port` and rewrites `localhost` and wildcard bind addresses (`0.0.0.0`, `::`, `[::]`, `::1`) to `127.0.0.1`, since clients can't reliably connect to a wildcard/`::1` address as a destination.
- `readProjectIdGuess()` — best-effort project ID: checks `FIRESTORE_EMULATOR_PROJECT` / `GCLOUD_PROJECT`, then `.firebaserc` (walking up from cwd), falling back to Firebase's conventional `demo-project` placeholder.
- `scanRunningEmulators()` — merges the hub-file scan and `scanEnv()`, de-duplicating by Firestore `host:port` so one running emulator isn't reported twice. Exported for reuse.
- The `emulators:scanHub` IPC handler now calls `scanRunningEmulators()`.

## Testing / verification
- Confirmed a Firestore-only emulator (`FIRESTORE_EMULATOR_HOST` / `FIRESTORE_EMULATOR_PROJECT`) is discovered with the correct project ID and connects over `127.0.0.1`, and its collections appear in FireStudio.
- `pnpm run lint`, `pnpm run format:check`, `pnpm run typecheck` → all pass (controller is plain JS; formatted by prettier).

## Notes
- Env-var discovery is additive — the existing hub-file scan still runs, and results are merged.
- This branch also includes the `localStorage` test-shim fix (from `fix/tests-localstorage-polyfill`) so CI tests pass on runtimes where jsdom doesn't expose `localStorage`.